### PR TITLE
Update vcpkg-configuration.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b1e15efef6758eaa0beb0a8732cfa66f6a68a81d",
+    "baseline": "2e6fcc44573d091af0321f99c89b212997a76f1f",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This pull request updates the vcpkg baseline in the `vcpkg-configuration.json` file to a newer commit. This ensures that dependencies managed by vcpkg will use the latest baseline from the upstream repository.

- Dependency management:
  * Updated the `baseline` field in `vcpkg-configuration.json` to point to commit `2e6fcc44573d091af0321f99c89b212997a76f1f` from the vcpkg repository, ensuring the project uses the latest package definitions.