### PR TITLE
Update vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
       "name": "curl",
       "default-features": false,
       "features": [
-        "sspi"
+        "ssl"
       ],
       "platform": "(windows & !uwp) | mingw"
     },


### PR DESCRIPTION
This pull request makes a small change to the `vcpkg.json` file, updating the `curl` dependency to use the `ssl` feature instead of `sspi` on Windows and MinGW platforms.