### PR TITLE
Add uwebsockets dependency to vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -25,6 +25,13 @@
       "default-features": false
     },
     "stb",
-    "tesseract"
+    "tesseract",
+    {
+      "name": "uwebsockets",
+      "default-features": false,
+      "features": [
+        "zlib"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Added uwebsockets with zlib feature and default-features disabled to the vcpkg dependencies list to support new functionality or requirements.