### PR TITLE
Update Tesseract port and dependencies in vcpkg

### DIFF
--- a/vcpkg-overlay-ports/tesseract/portfile.cmake
+++ b/vcpkg-overlay-ports/tesseract/portfile.cmake
@@ -10,18 +10,17 @@ vcpkg_from_github(
 )
 vcpkg_find_acquire_program(PKGCONFIG)
 
+string(APPEND VCPKG_C_FLAGS " -DTESSERACT_DISABLE_DEBUG_FONTS")
+string(APPEND VCPKG_CXX_FLAGS " -DTESSERACT_DISABLE_DEBUG_FONTS")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TRAINING_TOOLS=OFF
         -DDISABLE_ARCHIVE=ON
         -DDISABLE_CURL=ON
-        -DUSE_SYSTEM_ICU=True
-        -DCMAKE_REQUIRE_FIND_PACKAGE_Leptonica=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_OpenCL=ON
-        -DLeptonica_DIR=YES
+        -DUSE_SYSTEM_ICU=ON
         -DSW_BUILD=OFF
-        -DLEPT_TIFF_RESULT=ON
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_OpenCL
@@ -32,14 +31,14 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tesseract)
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/tesseract/TesseractConfig.cmake"
-    "find_dependency(Leptonica)"
-[[
-find_dependency(CURL)
-find_dependency(Leptonica)
-find_dependency(LibArchive)
-]]
-)
+# vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/tesseract/TesseractConfig.cmake"
+#     "find_dependency(Leptonica)"
+# [[
+# find_dependency(CURL)
+# find_dependency(Leptonica)
+# find_dependency(LibArchive)
+# ]]
+# )
 
 vcpkg_copy_tools(TOOL_NAMES tesseract AUTO_CLEAN)
 vcpkg_fixup_pkgconfig()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,6 +19,11 @@
     },
     "fmt",
     "gtest",
+    "leptonica",
+    {
+      "name": "libuv",
+      "platform": "windows | android"
+    },
     "ncnn",
     "nlohmann-json",
     {
@@ -27,12 +32,14 @@
     },
     "stb",
     "tesseract",
+    "usockets",
     {
       "name": "uwebsockets",
       "default-features": false,
       "features": [
         "zlib"
       ]
-    }
+    },
+    "zlib"
   ]
 }


### PR DESCRIPTION
This pull request updates the Tesseract port configuration and its dependencies to improve build reliability and compatibility. The most important changes include adjustments to compiler flags, CMake options, and the list of dependencies in `vcpkg.json`.

**Build configuration improvements:**

* Added `-DTESSERACT_DISABLE_DEBUG_FONTS` to both `VCPKG_C_FLAGS` and `VCPKG_CXX_FLAGS` to disable debug fonts in Tesseract builds.
* Updated several CMake options: changed `USE_SYSTEM_ICU` to use `ON` instead of `True`, and removed or adjusted other options for cleaner configuration.

**Dependency management:**

* Added `leptonica`, `libuv` (platform-specific), `usockets`, and `zlib` to the list of dependencies in `vcpkg.json`, ensuring these libraries are properly included. [[1]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283R22-R26) [[2]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283R35-R43)

**CMake config and packaging:**

* Commented out the `vcpkg_replace_string` block that modified `TesseractConfig.cmake` dependencies, possibly to avoid redundant or problematic dependency declarations.Added leptonica, usockets, and zlib to vcpkg dependencies. Updated Tesseract portfile to set C/C++ flags for disabling debug fonts, corrected CMake options, and commented out unnecessary config string replacement.