### PR TITLE
Add symbol visibility flags to OBS triplets

### DIFF
--- a/vcpkg-triplets/arm64-osx-obs.cmake
+++ b/vcpkg-triplets/arm64-osx-obs.cmake
@@ -6,3 +6,5 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
 
 set(VCPKG_OSX_DEPLOYMENT_TARGET "12.0")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")

--- a/vcpkg-triplets/x64-linux-obs.cmake
+++ b/vcpkg-triplets/x64-linux-obs.cmake
@@ -4,5 +4,5 @@ set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
-set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2")
-set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2 -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2 -fvisibility=hidden -fvisibility-inlines-hidden")

--- a/vcpkg-triplets/x64-osx-obs.cmake
+++ b/vcpkg-triplets/x64-osx-obs.cmake
@@ -6,5 +6,5 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 
 set(VCPKG_OSX_DEPLOYMENT_TARGET "12.0")
-set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2")
-set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2 -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2 -fvisibility=hidden -fvisibility-inlines-hidden")


### PR DESCRIPTION
This pull request updates the vcpkg triplet configuration files to improve symbol visibility and optimize binary size and security. The main changes involve adding compiler flags to hide symbols by default for both C and C++ builds across Linux and macOS triplets.

Compiler flag updates for symbol visibility:

* Added the `-fvisibility=hidden` flag to `VCPKG_C_FLAGS` and both `-fvisibility=hidden` and `-fvisibility-inlines-hidden` to `VCPKG_CXX_FLAGS` in the following triplet files:
  * `vcpkg-triplets/x64-linux-obs.cmake`
  * `vcpkg-triplets/x64-osx-obs.cmake`
  * `vcpkg-triplets/arm64-osx-obs.cmake`

These changes ensure that only explicitly exported symbols are visible in the resulting binaries, which can help reduce binary size and improve encapsulation.Added -fvisibility=hidden and -fvisibility-inlines-hidden to C and C++ flags in arm64-osx-obs, x64-linux-obs, and x64-osx-obs triplets to improve symbol hiding and reduce binary size.